### PR TITLE
Use vanilla functions to check for sprinkler pressure nozzle

### DIFF
--- a/LineSprinklersRedux/Framework/Sprinkler.cs
+++ b/LineSprinklersRedux/Framework/Sprinkler.cs
@@ -209,12 +209,7 @@ namespace LineSprinklersRedux.Framework
 
         private static bool HasPressureNozzle(SObject sprinkler)
         {
-            if (!IsLineSprinkler(sprinkler)) return false;
-            if (sprinkler.heldObject.Value != null)
-            {
-                return sprinkler.heldObject.Value.QualifiedItemId == "(O)915";
-            }
-            return false;
+            return IsLineSprinkler(sprinkler) && sprinkler.GetBaseRadiusForSprinkler() != sprinkler.GetModifiedRadiusForSprinkler();
         }
     }
 }


### PR DESCRIPTION
Using vanilla functions to check for pressure nozzle on sprinkler allows better compatibility with mods that add custom pressure nozzle like items.
I have one such mod that does this: https://www.nexusmods.com/stardewvalley/mods/25326
